### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server that enables semantic search and retrieval of documentation using a vector database (Qdrant). This server allows you to add documentation from URLs or local files and then search through them using natural language queries.
 
+<a href="https://glama.ai/mcp/servers/q4uywrflxx"><img width="380" height="200" src="https://glama.ai/mcp/servers/q4uywrflxx/badge" alt="MCP-Ragdocs MCP server" /></a>
+
 ## Version
 
 Current version: 0.1.6


### PR DESCRIPTION
This PR adds a badge for the MCP-Ragdocs server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/q4uywrflxx"><img width="380" height="200" src="https://glama.ai/mcp/servers/q4uywrflxx/badge" alt="MCP-Ragdocs MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.